### PR TITLE
Various fix-ups, Sign Schnorr, UI polish & nits

### DIFF
--- a/inter-wallet-transfer/qt.py
+++ b/inter-wallet-transfer/qt.py
@@ -1,8 +1,11 @@
 from PyQt5 import QtGui
+from PyQt5 import QtCore
 
 import electroncash.version, os
 from electroncash.i18n import _
 from electroncash.plugins import BasePlugin, hook
+from electroncash_gui.qt.util import destroyed_print_error
+from electroncash.util import finalization_print_error
 
 
 class Plugin(BasePlugin):
@@ -20,6 +23,9 @@ class Plugin(BasePlugin):
     def fullname(self):
         return 'Inter-Wallet Transfer'
 
+    def diagnostic_name(self):
+        return "InterWalletTransfer"
+
     def description(self):
         return _("Plugin Inter-Wallet Transfer")
 
@@ -33,11 +39,11 @@ class Plugin(BasePlugin):
 
     @hook
     def update_contact(self, address, new_entry, old_entry):
-        print("update_contact", address, new_entry, old_entry)
+        self.print_error("update_contact", address, new_entry, old_entry)
 
     @hook
     def delete_contacts(self, contact_entries):
-        print("delete_contacts", contact_entries)
+        self.print_error("delete_contacts", contact_entries)
 
     @hook
     def init_qt(self, qt_gui):
@@ -60,7 +66,7 @@ class Plugin(BasePlugin):
         """
         wallet_name = window.wallet.basename()
         self.wallet_windows[wallet_name] = window
-        print("wallet loaded")
+        self.print_error("wallet loaded")
         self.add_ui_for_wallet(wallet_name, window)
         self.refresh_ui_for_wallet(wallet_name)
 
@@ -73,31 +79,48 @@ class Plugin(BasePlugin):
         self.remove_ui_for_wallet(wallet_name, window)
 
 
+    @staticmethod
+    def _get_icon() -> QtGui.QIcon:
+        if QtCore.QFile.exists(":icons/preferences.png"):
+            icon = QtGui.QIcon(":icons/preferences.png")
+        else:
+            # png not found, must be new EC; try new EC icon -- svg
+            icon = QtGui.QIcon(":icons/preferences.svg")
+        return icon
+
     def add_ui_for_wallet(self, wallet_name, window):
         from .ui import LoadRWallet
         l = LoadRWallet(window, self, wallet_name)
         tab = window.create_list_tab(l)
         self.lw_tabs[wallet_name] = tab
         self.lw_tab[wallet_name] = l
-        window.tabs.addTab(tab,  QtGui.QIcon(":icons/preferences.png"), _('Inter-Wallet Transfer'))
+
+        window.tabs.addTab(tab, self._get_icon(), _('Inter-Wallet Transfer'))
 
     def remove_ui_for_wallet(self, wallet_name, window):
 
-        wallet_tab = self.lw_tabs.get(wallet_name, None)
-        widget = self.lw_tab.get(wallet_name, None)
+        wallet_tab = self.lw_tabs.get(wallet_name)
+        widget = self.lw_tab.get(wallet_name)
         if wallet_tab is not None:
             if widget and callable(getattr(widget, 'kill_join', None)):
                 widget.kill_join()  # kill thread, wait for up to 2.5 seconds for it to exit
+            if widget and callable(getattr(widget, 'clean_up', None)):
+                widget.clean_up()  # clean up wallet and stop its threads
             del self.lw_tab[wallet_name]
             del self.lw_tabs[wallet_name]
-            i = window.tabs.indexOf(wallet_tab)
-            window.tabs.removeTab(i)
+            if wallet_tab:
+                i = window.tabs.indexOf(wallet_tab)
+                window.tabs.removeTab(i)
+                wallet_tab.deleteLater()
+                self.print_error("Removed UI for", wallet_name)
 
     def refresh_ui_for_wallet(self, wallet_name):
-        wallet_tab = self.lw_tabs[wallet_name]
-        wallet_tab.update()
-        wallet_tab = self.lw_tab[wallet_name]
-        wallet_tab.update()
+        wallet_tab = self.lw_tabs.get(wallet_name)
+        if wallet_tab:
+            wallet_tab.update()
+        wallet_tab = self.lw_tab.get(wallet_name)
+        if wallet_tab:
+            wallet_tab.update()
 
     def switch_to(self, mode, wallet_name, recipient_wallet, time, password):
         window=self.wallet_windows[wallet_name]
@@ -105,12 +128,19 @@ class Plugin(BasePlugin):
             l = mode(window, self, wallet_name, recipient_wallet,time, password=password)
 
             tab = window.create_list_tab(l)
-            i = window.tabs.indexOf(self.lw_tabs.get(wallet_name, None))
+            destroyed_print_error(tab)  # track object lifecycle
+            finalization_print_error(tab)  # track object lifecycle
+
+            old_tab = self.lw_tabs.get(wallet_name)
+            i = window.tabs.indexOf(old_tab)
 
             self.lw_tabs[wallet_name] = tab
             self.lw_tab[wallet_name] = l
-            window.tabs.addTab(tab,  QtGui.QIcon(":icons/preferences.png"), _('Inter-Wallet Transfer'))
-            window.tabs.removeTab(i)
-        except Exception as es:
-            print(es)
+            window.tabs.addTab(tab, self._get_icon(), _('Inter-Wallet Transfer'))
+            if old_tab:
+                window.tabs.removeTab(i)
+                old_tab.searchable_list.deleteLater()
+                old_tab.deleteLater()  # Qt (and Python) will proceed to delete this widget
+        except Exception as e:
+            self.print_error(repr(e))
             return

--- a/inter-wallet-transfer/ui.py
+++ b/inter-wallet-transfer/ui.py
@@ -152,7 +152,7 @@ class TransferringUTXO(MessageBoxMixin, PrintError, MyTreeWidget):
         self.timer = QTimer(self)
         self.timer.setSingleShot(False)
         self.timer.timeout.connect(self.update_sig)
-        self.timer.start(1000)
+        self.timer.start(2000)  # update every 2 seconds since the granularity of our "When" column is ~5 seconds
         self.wallet = tab.recipient_wallet
 
     def create_menu(self, position):
@@ -300,6 +300,7 @@ class Transfer(MessageBoxMixin, PrintError, QWidget):
             coin = self.utxos.pop(0)
             name = get_name(coin)
             self.tu.sending = name
+            self.tu.update_sig.emit()  # have the widget immediately display "Processing"
             while not self.recipient_wallet.is_up_to_date():
                 ''' We must wait for the recipient wallet to finish synching...
                 Ugly hack.. :/ '''
@@ -313,7 +314,7 @@ class Transfer(MessageBoxMixin, PrintError, QWidget):
             else:
                 self.tu.failed_utxos[name] = err
             self.tu.sending = None
-            self.tu.update_sig.emit()
+            self.tu.update_sig.emit()  # have the widget immediately show "Sent or "Failed"
         # Emit a signal which will end up calling switch_signal_slot
         # in the main thread; we need to do this because we must now update
         # the GUI, and we cannot update the GUI in non-main-thread

--- a/inter-wallet-transfer/ui.py
+++ b/inter-wallet-transfer/ui.py
@@ -144,6 +144,8 @@ class TransferringUTXO(MessageBoxMixin, PrintError, MyTreeWidget):
         self.sent_utxos = dict()
         self.failed_utxos = dict()
         self.sending = None
+        self.check_icon = self._get_check_icon()
+        self.fail_icon = self._get_fail_icon()
         self.update_sig.connect(self.update)
         self.monospace_font = QFont(MONOSPACE_FONT)
         self.italic_font = QFont(); self.italic_font.setItalic(True)
@@ -187,8 +189,6 @@ class TransferringUTXO(MessageBoxMixin, PrintError, MyTreeWidget):
         if not tab or not self.wallet:
             return
         self._recalc_times(tab.times)
-        check_icon = self._get_check_icon()
-        fail_icon = self._get_fail_icon()
         base_unit = self.main_window.base_unit()
         for i, u in enumerate(self.utxos):
             address = u['address'].to_ui_string()
@@ -202,13 +202,13 @@ class TransferringUTXO(MessageBoxMixin, PrintError, MyTreeWidget):
             if is_sent:
                 status = _("Sent")
                 when = age(ts, include_seconds=True)
-                icon = check_icon
+                icon = self.check_icon
             else:
                 failed_reason = self.failed_utxos.get(name)
                 if failed_reason:
                     status = _("Failed")
                     when = failed_reason
-                    icon = fail_icon
+                    icon = self.fail_icon
                     when_font = self.italic_font
                 elif name == self.sending:
                     status = _("Processing")
@@ -216,7 +216,7 @@ class TransferringUTXO(MessageBoxMixin, PrintError, MyTreeWidget):
                     when_font = self.italic_font
                 else:
                     status = _("Queued")
-                    when = age(max(self.t0 + self.times_secs[i], time.time()+1.0), include_seconds=True)
+                    when = age(max(self.t0 + self.times_secs[i], time.time()+0.5), include_seconds=True)
 
             item = SortableTreeWidgetItem([address, value, time.strftime('%H:%M', self.times[i]), when, status])
             item.setFont(0, self.monospace_font)
@@ -337,7 +337,7 @@ class Transfer(MessageBoxMixin, PrintError, QWidget):
 
     def send_tx(self, coin: dict) -> str:
         ''' Returns the failure reason as a string on failure, or 'None'
-         on success. '''
+        on success. '''
         self.wallet.add_input_info(coin)
         inputs = [coin]
         recipient_address = self.recipient_wallet and self.recipient_wallet.get_unused_address()


### PR DESCRIPTION
Note that this would close #6 

- Fixed the layout of the transfer QTreeWidget to conform to the UI
  look/feel of Electron Cash (Addresses & amounts should be monospace)
- Laid out the tree widget to make it a little easier to read.
- Made the tree widget update itself in real-time as the plugin runs
- Fixed memory leaks where objects wouldn't be destroyed when using
  'switch_to'
- Fixed the tmp wallet file not always being deleted
- Fixed icon(s) to work with newer + older EC
- Transfers write to history label (description)
- Aborting the transfer now stops the tmp wallet properly (stops the
  verifier, synchronizer, cashacct engine, etc).
- Made the timing calculation code and the times displayed in the Tree
  Widget more precise.
- Tx's can sign with schnorr if schnorr is enabled and available
- If broadcast or other failure, the UI shows this to the user (rather than 
  crashing the send_all thread which is what would happen before)
- Fee is estimated correctly by first estimating tx size based on
  schnorr/non-schnorr setting (1.0 sats/B hard-coded for fee rate, as
  before).
- Plugin warns and refuses to run if EC is started in --offline mode.
- Misc: Don't inherit from QDialog if not actually a dialog.
- Allow user to specify floating-point hours, rather than just integers. 
- Various other nits

See attached screenshot:

<img width="953" alt="Screen Shot 2019-07-31 at 2 16 50 AM" src="https://user-images.githubusercontent.com/266627/62171930-5c9fe000-b339-11e9-9728-be9ecb2c0e5b.png">
