### PR TITLE
Updated plugin to fix a UI glitch, plus linted the code

### DIFF
--- a/inter-wallet-transfer/qt.py
+++ b/inter-wallet-transfer/qt.py
@@ -1,11 +1,12 @@
 from PyQt5 import QtGui
 from PyQt5 import QtCore
 
-import electroncash.version, os
 from electroncash.i18n import _
 from electroncash.plugins import BasePlugin, hook
 from electroncash_gui.qt.util import destroyed_print_error
 from electroncash.util import finalization_print_error
+
+from . import ui
 
 
 class Plugin(BasePlugin):
@@ -28,7 +29,6 @@ class Plugin(BasePlugin):
 
     def description(self):
         return _("Plugin Inter-Wallet Transfer")
-
 
     def on_close(self):
         """
@@ -70,14 +70,12 @@ class Plugin(BasePlugin):
         self.add_ui_for_wallet(wallet_name, window)
         self.refresh_ui_for_wallet(wallet_name)
 
-
     @hook
     def close_wallet(self, wallet):
         wallet_name = wallet.basename()
         window = self.wallet_windows[wallet_name]
         del self.wallet_windows[wallet_name]
         self.remove_ui_for_wallet(wallet_name, window)
-
 
     @staticmethod
     def _get_icon() -> QtGui.QIcon:
@@ -89,8 +87,7 @@ class Plugin(BasePlugin):
         return icon
 
     def add_ui_for_wallet(self, wallet_name, window):
-        from .ui import LoadRWallet
-        l = LoadRWallet(window, self, wallet_name)
+        l = ui.LoadRWallet(window, self, wallet_name)
         tab = window.create_list_tab(l)
         self.lw_tabs[wallet_name] = tab
         self.lw_tab[wallet_name] = l

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "display_name": "Inter-Wallet Transfer",
-    "version": "1.2",
+    "version": "1.3",
     "description": "A plugin, that sends your coins to another wallet one by one, every time to a fresh address.",
     "project_url": "https://github.com/KarolTrzeszczkowski/Inter-Wallet-Transfer-EC-plugin/",
     "minimum_ec_version": "4.0",


### PR DESCRIPTION
The UI glitch was that the initial screen (`LoadRWallet`) would have a
possible "stale" view of the coins in the wallet if the wallet was up
for a while with the plugin loaded, and it got sent new coins in the
meantime, so the transfer "tx/hr" stat would be inaccurate.

So, in this commit, the initial screen was updated to listen for the
`history_updated_signal` and to update `LoadRWallet`'s self.utxos when
that signal arrives, so that the stats in the UI would be accurate.

Also in this commit: Did some python code linting to get the code more
in-line with pep8.
